### PR TITLE
fix(auth): Show user-friendly error toast on login failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,7 @@ sketch
 .history
 .ionide
 
+# Supabase temp files
+supabase/.temp/
+
 # End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode,react

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -41,7 +41,9 @@ export function LoginForm({
 			});
 
 		if (error) {
-			console.error("Error al iniciar sesión", error.message);
+			toast.error(
+				"Credenciales incorrectas. Verificá tu email y contraseña.",
+			);
 			return;
 		}
 


### PR DESCRIPTION
Replace console.error with a toast notification when login credentials are invalid, improving the user experience with a visible error message.

chore: Ignore supabase/.temp/ directory in git